### PR TITLE
Fix: non-windows resolution of subprocess

### DIFF
--- a/pyhidra/launcher.py
+++ b/pyhidra/launcher.py
@@ -129,7 +129,7 @@ class PyhidraLauncher:
             self.check_ghidra_version()
 
             if self.java_home is None:
-                java_home = subprocess.check_output(_GET_JAVA_HOME, encoding="utf-8")
+                java_home = subprocess.check_output(_GET_JAVA_HOME, encoding="utf-8",shell=True)
                 self.java_home = Path(java_home.rstrip())
 
             jpype.startJVM(


### PR DESCRIPTION
Adds the `shell=True` argument to `subprocess.check_output` to fix #1.

Only tested on environment specified.

Target: OSX 11.6.4, Python 3.7.6, Ghidra 10.2 DEV

FIXES: #1 