### PR TITLE
Fix cross-arch support for delimiters in java class path

### DIFF
--- a/pyhidra/javac.py
+++ b/pyhidra/javac.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 from pathlib import Path
+from os import pathsep
 
 
 COMPILER_OPTIONS = ["-target", "11"]
@@ -36,7 +37,7 @@ def java_compile(src_path: Path, jar_path: Path):
         outdir = Path(out).resolve()
         compiler = ToolProvider.getSystemJavaCompiler()
         fman = compiler.getStandardFileManager(None, None, None)
-        cp = [JPath @ (Path(p)) for p in System.getProperty("java.class.path").split(';')]
+        cp = [JPath @ (Path(p)) for p in System.getProperty("java.class.path").split(pathsep)]
         fman.setLocationFromPaths(StandardLocation.CLASS_PATH, cp)
         if src_path.is_dir():
             fman.setLocationFromPaths(StandardLocation.SOURCE_PATH, [JPath @ (src_path.resolve())])


### PR DESCRIPTION
This PR replaces the hardcoded delimiter in java class path presented an issue in #3 the os pathsep option.

Only tested on environment specified.

Target: OSX 11.6.4, Python 3.7.6, Ghidra 10.2 DEV

FIXES: #3 