### PR TITLE
Allow Java versions > 11 to be targeted

### DIFF
--- a/pyhidra/javac.py
+++ b/pyhidra/javac.py
@@ -36,6 +36,13 @@ def java_compile(src_path: Path, jar_path: Path):
         outdir = Path(out).resolve()
         compiler = ToolProvider.getSystemJavaCompiler()
         fman = compiler.getStandardFileManager(None, None, None)
+
+        # allow for target versions > 11
+        latest_version = compiler.getSourceVersions().toArray()[0].latest()
+        latest_num = int(str(latest_version).split("_")[1])
+        if latest_num > 11:
+            COMPILER_OPTIONS[1] = str(latest_num)
+        
         cp = [JPath @ (Path(p)) for p in System.getProperty("java.class.path").split(';')]
         fman.setLocationFromPaths(StandardLocation.CLASS_PATH, cp)
         if src_path.is_dir():


### PR DESCRIPTION
This PR uses the latest supported compiler version as the string target compiler option when compiling. This solves the issue presented in #4.

Only tested on environment specified.

Target: OSX 11.6.4, Python 3.7.6, Ghidra 10.2 DEV, openjdk 14.0.2

FIXES: #4