### PR TITLE
Allow parsing of empty java properties

### DIFF
--- a/pyhidra/version.py
+++ b/pyhidra/version.py
@@ -7,7 +7,7 @@ from typing import NamedTuple, Union
 from pyhidra import __version__
 from pyhidra.constants import GHIDRA_INSTALL_DIR
 
-_APPLICATION_PATTERN = re.compile(r"^application\.(\S+?)=(.+)$")
+_APPLICATION_PATTERN = re.compile(r"^application\.(\S+?)=(.*)$")
 _APPLICATION_PATH = GHIDRA_INSTALL_DIR / "Ghidra" / "application.properties"
 
 


### PR DESCRIPTION
Hi folks,

on my ArchLinux Ghidra install, /opt/ghidra/Ghidra/application.properties looks like this:

```
$> cat /opt/ghidra/Ghidra/application.properties                                                                                                                                                                                                                 
application.revision.ghidra-Ghidra_10.1.2_build=
application.build.date=2022-Jan-26 2220 CET
application.build.date.short=20220126
application.name=Ghidra
application.version=10.1.2
application.release.name=DEV
application.layout.version=1
application.gradle.min=6.8
application.java.min=11
application.java.max=
application.java.compiler=11
```

Your old regex implementation stops at the first line, because nothing is assigned to the property. This pull requests allows for empty properties.