### PR TITLE
skip unmatched lines in application.properties

### DIFF
--- a/pyhidra/version.py
+++ b/pyhidra/version.py
@@ -32,7 +32,7 @@ class ApplicationInfo:
         for line in _APPLICATION_PATH.read_text(encoding="utf8").splitlines():
             match = _APPLICATION_PATTERN.match(line)
             if not match:
-                break
+                continue
             attr = match.group(1).replace('.', '_').replace('-', '_')
             value = match.group(2)
             super().__setattr__(attr, value)


### PR DESCRIPTION
Ghidra loads the application.properties file with the [Properties](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Properties.html#load(java.io.Reader)) class, which allows for more variety in the property file than the current parsing allows. This adjustment skips lines that do not meet expectations instead of failing when they are encountered, making the parsing more resilient.

This is intended to resolve #12.