### PR TITLE
Ignore libjvm.debuginfo when searching for dynamic libjvm

### DIFF
--- a/pyhidra/launcher.py
+++ b/pyhidra/launcher.py
@@ -62,7 +62,8 @@ def _silence_java_output(stdout=True, stderr=True):
 
 def _get_libjvm_path(java_home: Path) -> Path:
     for p in java_home.glob("*/server/*jvm.*"):
-        return p
+        if p.suffix != ".debuginfo":
+            return p
 
 
 class PyhidraLauncher:


### PR DESCRIPTION
For openjdk installs with debuginfo, the glob for finding libjvm will also pick the debuginfo up:

```
/usr/lib/jvm/java-18-openjdk/lib/server/libjvm.debuginfo
/usr/lib/jvm/java-18-openjdk/lib/server/libjvm.so
```

This will result in pyhidra attempting to treat the debuginfo as the dynamic library path, preventing it from running at all.