### PR TITLE
handle python mod conflicts

### DIFF
--- a/pyhidra/constants.py
+++ b/pyhidra/constants.py
@@ -5,5 +5,3 @@ GHIDRA_INSTALL_DIR = pathlib.Path(os.environ["GHIDRA_INSTALL_DIR"])
 LAUNCH_PROPERTIES = GHIDRA_INSTALL_DIR / "support" / "launch.properties"
 UTILITY_JAR = GHIDRA_INSTALL_DIR / "Ghidra" / "Framework" / "Utility" / "lib" / "Utility.jar"
 LAUNCHSUPPORT = GHIDRA_INSTALL_DIR / "support" / "LaunchSupport.jar"
-GHIDRA_BASE_JAVA_PACKAGES = ["SWIG", "agent", "db", "decompiler", "docking", "foundation", "functioncalls", "generic", "ghidra", "help",
-                        "log", "mdemangler", "org", "pdb", "resources", "util", "utilities", "utility"]

--- a/pyhidra/constants.py
+++ b/pyhidra/constants.py
@@ -5,3 +5,5 @@ GHIDRA_INSTALL_DIR = pathlib.Path(os.environ["GHIDRA_INSTALL_DIR"])
 LAUNCH_PROPERTIES = GHIDRA_INSTALL_DIR / "support" / "launch.properties"
 UTILITY_JAR = GHIDRA_INSTALL_DIR / "Ghidra" / "Framework" / "Utility" / "lib" / "Utility.jar"
 LAUNCHSUPPORT = GHIDRA_INSTALL_DIR / "support" / "LaunchSupport.jar"
+GHIDRA_BASE_JAVA_PACKAGES = ["SWIG", "agent", "db", "decompiler", "docking", "foundation", "functioncalls", "generic", "ghidra", "help",
+                        "log", "mdemangler", "org", "pdb", "resources", "util", "utilities", "utility"]

--- a/pyhidra/launcher.py
+++ b/pyhidra/launcher.py
@@ -13,7 +13,7 @@ import jpype
 from jpype import imports
 
 from . import __version__
-from .constants import LAUNCH_PROPERTIES, LAUNCHSUPPORT, GHIDRA_INSTALL_DIR, UTILITY_JAR
+from .constants import LAUNCH_PROPERTIES, LAUNCHSUPPORT, GHIDRA_INSTALL_DIR, UTILITY_JAR, GHIDRA_BASE_JAVA_PACKAGES
 from .version import get_current_application, get_ghidra_version, MINIMUM_GHIDRA_VERSION, \
     ExtensionDetails
 
@@ -125,6 +125,18 @@ class PyhidraLauncher:
                 """).rstrip()
             )
 
+    @classmethod
+    def _wrap_mod(cls,mod):
+        return mod + "_"
+
+    @classmethod
+    def _wrap_ghidra_base_java_packages(cls):        
+        """
+        Wraps Ghidra's base Java packages to avoid name conflicts with Python modules
+        """
+        for mod in GHIDRA_BASE_JAVA_PACKAGES:
+            imports.registerDomain(cls._wrap_mod(mod), mod)
+
     def start(self):
         """
         Starts Jpype connection to Ghidra (if not already started).
@@ -147,6 +159,8 @@ class PyhidraLauncher:
                 classpath=self.class_path
             )
             imports.registerDomain("ghidra")
+
+            self._wrap_ghidra_base_java_packages()
 
             from ghidra import GhidraLauncher
 

--- a/pyhidra/launcher.py
+++ b/pyhidra/launcher.py
@@ -11,7 +11,7 @@ from typing import NoReturn
 
 import jpype
 from jpype import imports, _jpype
-from importlib.machinery import ModuleSpec as _ModuleSpec
+from importlib.machinery import ModuleSpec
 
 from . import __version__
 from .constants import LAUNCH_PROPERTIES, LAUNCHSUPPORT, GHIDRA_INSTALL_DIR, UTILITY_JAR
@@ -76,12 +76,10 @@ class _PyhidraImportLoader:
             return None
 
         if name.endswith('_') and _jpype.isPackage(name[:-1]):
-            ms = _ModuleSpec(name, self)
-            ms._jname = name[:-1]
-            return ms
+            return ModuleSpec(name, self)
 
     def create_module(self, spec):
-        return _jpype._JPackage(spec._jname)
+        return _jpype._JPackage(spec.name[:-1])
 
     def exec_module(self, fullname):
         pass


### PR DESCRIPTION
When trying to port over [this script](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/PDB/developer_scripts/PdbSymbolServerExamplePrescript.java) using Ghidra `pdb` Java package to Python leveraging `pyhidra`, I realized an issue with a python stdlib name `pdb` (python debugger) conflicting with Ghidra's base Java package `pdb`.  

When I tried to import `pdb` I received the python stdlib module: 

```python
import pdb
print(pdb.__file__)
"/usr/local/lib/python3.10/pdb.py"
```

It ends up using a different standard `frozen_importlib_external.SourceFileLoader` when imported:
```python
spec = importlib.util.find_spec("pdb")
print(spec)
ModuleSpec(name='pdb', loader=<_frozen_importlib_external.SourceFileLoader object at 0xffff5c946920>, origin='/usr/local/lib/python3.10/pdb.py')
```
instead of the desired jpype loader for the module. 
```python
ModuleSpec(name='pdb', loader=<jpype.imports._JImportLoader object at 0xffff892dfd90>)
```

This is actually a [standard issue](https://jpype.readthedocs.io/en/latest/userguide.html#importing-java-classes) with `jpype`.

> Python always imports local directories as modules before calling the Java importer.

This is because the `jpype` module spec finder is the last in the list for `sys.meta_path` after it is appended using https://github.com/jpype-project/jpype/blob/f6ad8f4e5c6ece1f5a224de420968fa508f109fa/jpype/imports.py#L224-L225:

```python
# Install hooks into python importlib
sys.meta_path.append(_JImportLoader())
```

```python 
print(sys.meta_path)
[<class '_frozen_importlib.BuiltinImporter'>, <class '_frozen_importlib.FrozenImporter'>, <class '_frozen_importlib_external.PathFinder'>, <pkg_resources.extern.VendorImporter object at 0xffff9c4f6920>, <jpype.imports._JImportLoader object at 0xffff9beb1540>]
```

There are several ways to go about handling the issue. The developer could simply give priority to the `jpype` finder by modifying the sys.meta_path order, giving precedence to `_JImportLoader`:

Option 1:
```python
sys.meta_path.reverse()
import pdb
sys.meta_path.reverse()  # restore when done 
```

Option2: 
```python
sys.meta_path.insert(0,_JImportLoader()) # set it as first entry
```

The problem here is that this would simply reverse the problem. Then standard python modules that a dev might want to access wouldn't be available by the standard `import <mod>`.

I thought maybe a class method to ensure the load of a Java module might work. You could force the load of a module using the `jpype` loader by adding this class to the base class of launcher.

```python
@staticmethod
def load_java_mod_from_jpype(modname) ->  importlib.machinery.ModuleSpec:
    """
    Load a module using jpype loader ignoring find order in sys.meta_env"
    """        
    module = None 
    
    # Find spec using Jpype loader
    spec = importlib.util.spec_from_loader(modname,imports._JImportLoader())
    if spec is not None:
        spec._jname = modname
        module = importlib.util.module_from_spec(spec)
        # load module in sys.modules
        sys.modules[modname] = module
        spec.loader.exec_module(module)

    return module
```

The issue I see with this is that you would still need to call this method for each package you wanted to ensure used a Java package.

```python
pdb = launcher.load_java_mod_from_jpype("pdb")

pdb.method(arg,arg1)
```

or just call it first and then call import as the mod would be loaded in sys.modules

```python
launcher.load_java_mod_from_jpype("pdb")  
import pdb

pdb.method(arg,arg1)
```

After seeing how `jpype` ["handles" the issue](https://jpype.readthedocs.io/en/latest/imports.html#keyword-naming), I think it might be easier to follow their lead.  They simply wrap conflicting keywords to avoid the conflict. 

I derived the base Java package names from sorting all the top level directories from ghidra source:
```python
# find /ghidra/ -name *src.zip -exec sh -c "zipinfo -1 {}" \; | grep -v "/." | sort | uniq -c | grep '/'

GHIDRA_BASE_JAVA_PACKAGES = ["SWIG", "agent", "db", "decompiler", "docking", "foundation", "functioncalls", "generic", "ghidra", "help", "log", "mdemangler", "org", "pdb", "resources", "util", "utilities", "utility"]
```

We can register all the base [Ghidra base Java package names](https://github.com/clearbluejar/pyhidra/blob/1b8122310fadde566def33903c4303ae5b55601b/pyhidra/constants.py#L8) with a name that won't conflict.  Simply [append](https://github.com/clearbluejar/pyhidra/blob/handle-python-mod-conflicts-with-ghidra-java-packages/pyhidra/launcher.py#L133) a '\_' to all Ghidra base Java packages names in the [initialization](https://github.com/clearbluejar/pyhidra/blob/1b8122310fadde566def33903c4303ae5b55601b/pyhidra/launcher.py#L163).

pyhidra/launcher.py

This would allow the developer to do the following and know that they are importing the correct package:

```
import pdb_ as pdb
```

The changes for the PR add a method inside the base `launcher.start` that would initialize each base class with the `jpype.imports.registerDomain`. From that point on, all the base classes are available to to developer without conflicts.  The developer can still [use the original](https://github.com/clearbluejar/pyhidra/blob/1b8122310fadde566def33903c4303ae5b55601b/tests/test_core.py#L102) `import <non conflicting base class>` but will [need to use](https://github.com/clearbluejar/pyhidra/blob/1b8122310fadde566def33903c4303ae5b55601b/tests/test_core.py#L106) the `import mod_ as mod` for conflicting packages.  This should somewhat future proof as python and Ghidra Java packages change.

Might want to add something to the README to account for this. Something like:
```markdown
### Handling Python module and Java Package naming conflicts

There is an issue when you want to import a Java package whose name conflicts with a Python standard module. This is  is actually a [standard issue](https://jpype.readthedocs.io/en/latest/userguide.html#importing-java-classes) with `jpype`.

When modules name conflict:

> Python always imports local directories as modules before calling the Java importer. [jpype](https://jpype.readthedocs.io/en/latest/userguide.html#importing-java-classes)

To over come a conflicting module, `pyhidra` simply registers the module with a '\_' so that it is available for import without conflict. 

`import pdb_ as pdb`

This will ensure that the Java package is loaded instead of the standard lib python module.
```
