### PR TITLE
add script folder to plugin

### DIFF
--- a/pyhidra/ghidra_scripts/PyhidraBasics.py
+++ b/pyhidra/ghidra_scripts/PyhidraBasics.py
@@ -1,0 +1,71 @@
+# Examples of Pyhidra-specific functionality
+# @category: Examples.Python
+
+
+# we can import java libraries just as if they were python libraries
+from java.util import LinkedList
+
+# and then use them like they are natural classes
+java_list = LinkedList([1,2,3])
+print(f"linked list object class: {java_list.__class__}")
+
+# importing and using Ghidra modules is the same
+from ghidra.program.flatapi import FlatProgramAPI
+print(f"max references to a flat program api: {FlatProgramAPI.MAX_REFERENCES_TO}")
+
+# we can also do normal python-ish things on our Java objects, like:
+# indexing
+print(f"first element of the list: {java_list[0]}")
+
+# slicing
+print(f"first two elements of the list: {java_list[0:2]}")
+
+# list comprehension
+java_list_double = [i * 2 for i in java_list]
+print(f"list comprehension result: {java_list_double}")
+
+# automatic calls to getters
+print("current program name: {currentProgram.name}") # calls currentProgram.getName()
+
+# here's an example of how this stuff might come in handy with Ghidra:
+print('current program memory blocks:\n')
+for block in currentProgram.memory.blocks:
+  print(block.name)
+
+
+# many Ghidra functions need a Java-native array to pass or receive values
+# JPype provides objects of JByte, JChar, etc. to meet this need
+# this example demonstrates how you would create an array of bytes to get
+# the first 10 bytes of memory from the .text section
+
+# we need this import to get at the helper classes
+import jpype
+
+# get the block we need
+block = currentProgram.memory.getBlock('.text')
+if block:
+  # the verbose way of getting the array
+  byte_array_maker = jpype.JArray(jpype.JByte)
+  byte_array = byte_array_maker(10)
+
+  # we also could have taken a shortcut with just:
+  # byte_array = jpype.JByte[10]
+
+  # let's have a look at our new object
+  print(f"array class: {byte_array.__class__}")
+  # will be <java class 'byte[]'>
+  print(f"array length: {len(byte_array)}")
+
+  # we can now use this array wherever a Java method requires a byte[] type
+  # the signature of getBytes is getBytes(Address addr, byte[] b)
+  block.getBytes(block.start, byte_array)
+
+  # after the call, we can get the bytes out as desired
+  # we just put them in a list comprehension here
+  print(f"first 10 bytes of .text: {['%#x' % ((b+256)%256) for b in byte_array]}")
+
+else:
+  print('no block named .text in this program.')
+
+# see the user manual of JPype for more details on interoperability:
+# https://jpype.readthedocs.io/en/latest/userguide.html

--- a/pyhidra/ghidra_scripts/PyhidraBasics.py
+++ b/pyhidra/ghidra_scripts/PyhidraBasics.py
@@ -25,12 +25,12 @@ java_list_double = [i * 2 for i in java_list]
 print(f"list comprehension result: {java_list_double}")
 
 # automatic calls to getters
-print("current program name: {currentProgram.name}") # calls currentProgram.getName()
+print(f"current program name: {currentProgram.name}") # calls currentProgram.getName()
 
 # here's an example of how this stuff might come in handy with Ghidra:
 print('current program memory blocks:\n')
 for block in currentProgram.memory.blocks:
-  print(block.name)
+    print(block.name)
 
 
 # many Ghidra functions need a Java-native array to pass or receive values
@@ -44,28 +44,28 @@ import jpype
 # get the block we need
 block = currentProgram.memory.getBlock('.text')
 if block:
-  # the verbose way of getting the array
-  byte_array_maker = jpype.JArray(jpype.JByte)
-  byte_array = byte_array_maker(10)
+    # the verbose way of getting the array
+    byte_array_maker = jpype.JArray(jpype.JByte)
+    byte_array = byte_array_maker(10)
 
-  # we also could have taken a shortcut with just:
-  # byte_array = jpype.JByte[10]
+    # we also could have taken a shortcut with just:
+    # byte_array = jpype.JByte[10]
 
-  # let's have a look at our new object
-  print(f"array class: {byte_array.__class__}")
-  # will be <java class 'byte[]'>
-  print(f"array length: {len(byte_array)}")
+    # let's have a look at our new object
+    print(f"array class: {byte_array.__class__}")
+    # will be <java class 'byte[]'>
+    print(f"array length: {len(byte_array)}")
 
-  # we can now use this array wherever a Java method requires a byte[] type
-  # the signature of getBytes is getBytes(Address addr, byte[] b)
-  block.getBytes(block.start, byte_array)
+    # we can now use this array wherever a Java method requires a byte[] type
+    # the signature of getBytes is getBytes(Address addr, byte[] b)
+    block.getBytes(block.start, byte_array)
 
-  # after the call, we can get the bytes out as desired
-  # we just put them in a list comprehension here
-  print(f"first 10 bytes of .text: {['%#x' % ((b+256)%256) for b in byte_array]}")
+    # after the call, we can get the bytes out as desired
+    # we just put them in a list comprehension here
+    print(f"first 10 bytes of .text: {['%#x' % ((b+256)%256) for b in byte_array]}")
 
 else:
-  print('no block named .text in this program.')
+    print('no block named .text in this program.')
 
 # see the user manual of JPype for more details on interoperability:
 # https://jpype.readthedocs.io/en/latest/userguide.html

--- a/pyhidra/launcher.py
+++ b/pyhidra/launcher.py
@@ -110,6 +110,21 @@ class PyhidraLauncher:
         self.vm_args += args
 
     @classmethod
+    def _copy_script_dir(self):
+        """
+        Copies the Ghidra script included with Pyhidra into the Extension
+        folder. This needs to happen before Ghidra is launched in order for
+        the script manager to recognize them.
+        """
+        pyhidra_path = Path(__file__).parent
+        lib_script_dir = pyhidra_path / "ghidra_scripts"
+
+        ghidra_path = get_current_application().extension_path / "pyhidra"
+        new_script_dir = ghidra_path / "ghidra_scripts"
+
+        shutil.copytree(lib_script_dir, new_script_dir)
+
+    @classmethod
     def _report_fatal_error(cls, title: str, msg: str) -> NoReturn:
         sys.exit(f"{title}: {msg}")
 
@@ -156,6 +171,10 @@ class PyhidraLauncher:
                 self.java_home = Path(java_home.rstrip())
 
             jvm = _get_libjvm_path(self.java_home)
+
+            # this needs to happen before Ghidra is launched so that the script
+            # directory is recognized and included in the Script Manager
+            self._copy_script_dir()
 
             jpype.startJVM(
                 str(jvm),

--- a/pyhidra/launcher.py
+++ b/pyhidra/launcher.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import os
 import platform
 import re
 import shutil
@@ -116,13 +117,14 @@ class PyhidraLauncher:
         folder. This needs to happen before Ghidra is launched in order for
         the script manager to recognize them.
         """
-        pyhidra_path = Path(__file__).parent
-        lib_script_dir = pyhidra_path / "ghidra_scripts"
-
         ghidra_path = get_current_application().extension_path / "pyhidra"
         new_script_dir = ghidra_path / "ghidra_scripts"
 
-        shutil.copytree(lib_script_dir, new_script_dir)
+        if not os.path.exists(new_script_dir):
+            pyhidra_path = Path(__file__).parent
+            lib_script_dir = pyhidra_path / "ghidra_scripts"
+
+            shutil.copytree(lib_script_dir, new_script_dir)
 
     @classmethod
     def _report_fatal_error(cls, title: str, msg: str) -> NoReturn:


### PR DESCRIPTION
Pyhidra is very useful for integrating other Python libraries into Ghidra tooling. However, I've found myself looking up some usage patterns in JPype documentation repeatedly, and believe that having an example script to directly reference in Ghidra would make things simpler and more accessible for myself and others. Other scripts that are determined to be useful/common that revolve around pyhidra could also be useful to include with the distribution in the future.

To that end, this change creates a `ghidra_scripts` folder that gets installed along with the extension. The only script included initially is a Pyhidra basics script that includes some common patterns, similar to the Jython basics script Ghidra comes with. These patterns have been useful for me, particularly the native Java array idioms, since Ghidra requires these in a few places to interact with its SDK.

Feedback is welcome! And of course, thanks a ton for this project, it is _essential_ to Ghidra (in my opinion).

EDIT: force push to fix spelling error