### PR TITLE
Check GHIDRA_INSTALL_DIR on Launcher initialization

### DIFF
--- a/pyhidra/launcher.py
+++ b/pyhidra/launcher.py
@@ -126,6 +126,15 @@ class PyhidraLauncher:
     """
 
     def __init__(self, verbose):
+        if GHIDRA_INSTALL_DIR is None:
+            self._report_fatal_error(
+                "GHIDRA_INSTALL_DIR is not set",
+                textwrap.dedent("""\
+                    Please set the GHIDRA_INSTALL_DIR environment variable
+                    to the directory where Ghidra is installed
+                """).rstrip()
+            )
+
         self._plugins = []
         self.verbose = verbose
         self.java_home = None
@@ -179,15 +188,6 @@ class PyhidraLauncher:
         """
         if jpype.isJVMStarted():
             return
-
-        if GHIDRA_INSTALL_DIR is None:
-            self._report_fatal_error(
-                "GHIDRA_INSTALL_DIR is not set",
-                textwrap.dedent("""\
-                    Please set the GHIDRA_INSTALL_DIR environment variable
-                    to the directory where Ghidra is installed
-                """).rstrip()
-            )
 
         self.check_ghidra_version()
 


### PR DESCRIPTION
This PR change the place where the `GHIDRA_INSTALL_DIR` env variable is checked in `PyhidraLauncher`, checking it at  the top of `PyhidraLauncher`'s constructor.
Currently the variable is checked inside the `start` function.

**Rationale**
When in a "bad" state, the program should exit as soon as possible to avoid continuing the execution.

The fact that the environment variable is checked later in the `start` function allows some weird behavior, specifically the following python *"pseudocode"* will crash:
```python3
import os
from pyhidra import PyhidraLauncher

del os.environ["GHIDRA_INSTALL_DIR"]
p = PyhidraLauncher()
p.add_vmargs('-XX:+PrintFlagsFinal')
p.start()
```

This is because inside the `__init__` constructor, `self.vm_args` is set to the return value of `_jvm_args()`, in [pyhidra/launcher.py#L134](https://github.com/dod-cyber-crime-center/pyhidra/blob/main/pyhidra/launcher.py#L134).

The `_jvm_args` function will return `None` since the `GHIDRA_INSTALL_DIR` is empty/not set, in [pyhidra/launcher.py#L40](https://github.com/dod-cyber-crime-center/pyhidra/blob/main/pyhidra/launcher.py#L40).

When `self.add_vmargs` is called later, it will trigger a `TypeError: unsupported operand type(s) for +=: 'NoneType' and 'tuple'`, in [pyhidra/launcher.py#L148](https://github.com/dod-cyber-crime-center/pyhidra/blob/main/pyhidra/launcher.py#L148).

For example, ghidriff by @clearbluejar is affected [ghidriff/ghidra_diff_engine.py#L98-L120](https://github.com/clearbluejar/ghidriff/blob/e08dea2392775ba4bcdb58a2c7272793c0101c89/ghidriff/ghidra_diff_engine.py#L98-L120)