### PR TITLE
Remove implicit Optional function arguments

### DIFF
--- a/pyhidra/core.py
+++ b/pyhidra/core.py
@@ -83,7 +83,7 @@ def _get_language(id: str) -> "Language":
     raise ValueError("Invalid Language ID: "+id)
 
 
-def _get_compiler_spec(lang: "Language", id: str = None) -> "CompilerSpec":
+def _get_compiler_spec(lang: "Language", id: Optional[str] = None) -> "CompilerSpec":
     if id is None:
         return lang.getDefaultCompilerSpec()
     from ghidra.program.model.lang import CompilerSpecID, CompilerSpecNotFoundException
@@ -98,11 +98,11 @@ def _get_compiler_spec(lang: "Language", id: str = None) -> "CompilerSpec":
 
 def _setup_project(
         binary_path: Union[str, Path],
-        project_location: Union[str, Path] = None,
-        project_name: str = None,
-        language: str = None,
-        compiler: str = None,
-        loader: Union[str, JClass] = None
+        project_location: Optional[Union[str, Path]] = None,
+        project_name: Optional[str] = None,
+        language: Optional[str] = None,
+        compiler: Optional[str] = None,
+        loader: Optional[Union[str, JClass]] = None
 ) -> Tuple["GhidraProject", "Program"]:
     from ghidra.base.project import GhidraProject
     from java.lang import ClassLoader
@@ -213,12 +213,12 @@ def _analyze_program(flat_api, program):
 @contextlib.contextmanager
 def open_program(
         binary_path: Union[str, Path],
-        project_location: Union[str, Path] = None,
-        project_name: str = None,
+        project_location: Optional[Union[str, Path]] = None,
+        project_name: Optional[str] = None,
         analyze=True,
-        language: str = None,
-        compiler: str = None,
-        loader: Union[str, JClass] = None
+        language: Optional[str] = None,
+        compiler: Optional[str] = None,
+        loader: Optional[Union[str, JClass]] = None
 ) -> ContextManager["FlatProgramAPI"]: # type: ignore
     """
     Opens given binary path in Ghidra and returns FlatProgramAPI object.
@@ -273,16 +273,16 @@ def open_program(
 
 @contextlib.contextmanager
 def _flat_api(
-        binary_path: Union[str, Path] = None,
-        project_location: Union[str, Path] = None,
-        project_name: str = None,
+        binary_path: Optional[Union[str, Path]] = None,
+        project_location: Optional[Union[str, Path]] = None,
+        project_name: Optional[str] = None,
         verbose=False,
         analyze=True,
-        language: str = None,
-        compiler: str = None,
-        loader: Union[str, JClass] = None,
+        language: Optional[str] = None,
+        compiler: Optional[str] = None,
+        loader: Optional[Union[str, JClass]] = None,
         *,
-        install_dir: Path = None
+        install_dir: Optional[Path] = None
 ):
     """
     Runs a given script on a given binary path.
@@ -345,16 +345,16 @@ def _flat_api(
 def run_script(
     binary_path: Optional[Union[str, Path]],
     script_path: Union[str, Path],
-    project_location: Union[str, Path] = None,
-    project_name: str = None,
-    script_args: List[str] = None,
+    project_location: Optional[Union[str, Path]] = None,
+    project_name: Optional[str] = None,
+    script_args: Optional[List[str]] = None,
     verbose=False,
     analyze=True,
-    lang: str = None,
-    compiler: str = None,
-    loader: Union[str, JClass] = None,
+    lang: Optional[str] = None,
+    compiler: Optional[str] = None,
+    loader: Optional[Union[str, JClass]] = None,
     *,
-    install_dir: Path = None
+    install_dir: Optional[Path] = None
 ):
     """
     Runs a given script on a given binary path.

--- a/pyhidra/gui.py
+++ b/pyhidra/gui.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import platform
 import sys
 import traceback
-from typing import NoReturn
+from typing import Optional, NoReturn
 import warnings
 
 import pyhidra
@@ -125,7 +125,7 @@ def _gui():
         _gui_default(install_dir)
 
 
-def gui(install_dir: Path = None):
+def gui(install_dir: Optional[Path] = None):
     """
     Starts the Ghidra GUI
 

--- a/pyhidra/launcher.py
+++ b/pyhidra/launcher.py
@@ -14,7 +14,7 @@ import tempfile
 import threading
 from importlib.machinery import ModuleSpec
 from pathlib import Path
-from typing import List, NoReturn, Tuple, Union
+from typing import Optional, List, NoReturn, Tuple, Union
 
 import jpype
 from jpype import imports, _jpype
@@ -129,7 +129,7 @@ class PyhidraLauncher:
     Base pyhidra launcher
     """
 
-    def __init__(self, verbose=False, *, install_dir: Path = None):
+    def __init__(self, verbose=False, *, install_dir: Optional[Path] = None):
         """
         Initializes a new `PyhidraLauncher`.
 

--- a/pyhidra/linux_shortcut.py
+++ b/pyhidra/linux_shortcut.py
@@ -3,6 +3,7 @@ import shlex
 import sys
 import sysconfig
 from pathlib import Path
+from typing import Optional
 
 desktop_entry = """\
 [Desktop Entry]
@@ -35,7 +36,7 @@ def extract_png(install_dir: Path) -> Path:
     return png_path
 
 
-def create_shortcut(install_dir: Path = None):
+def create_shortcut(install_dir: Optional[Path] = None):
     """Install a desktop entry on Linux machine."""
     pyhidra_exec = Path(sysconfig.get_path("scripts")) / "pyhidra"
     if not pyhidra_exec.exists():

--- a/pyhidra/mac_shortcut.py
+++ b/pyhidra/mac_shortcut.py
@@ -10,6 +10,7 @@ import sys
 from tempfile import TemporaryDirectory
 
 from pyhidra.linux_shortcut import extract_png
+from typing import Optional
 
 
 applications = Path("~/Applications").expanduser()
@@ -93,7 +94,7 @@ class AppBuilder:
         return self._tmpdir.__exit__(*args)
 
 
-def create_shortcut(install_dir: Path = None):
+def create_shortcut(install_dir: Optional[Path] = None):
     """Install a desktop entry on Mac machine."""
     if install_dir is None:
         install_dir = os.environ.get("GHIDRA_INSTALL_DIR")

--- a/pyhidra/script.py
+++ b/pyhidra/script.py
@@ -9,7 +9,7 @@ from collections.abc import ItemsView, KeysView
 from importlib.machinery import ModuleSpec, SourceFileLoader
 from pathlib import Path
 from jpype import JClass, JImplementationFor
-from typing import List
+from typing import Optional, List
 
 
 from .core import debug_callback
@@ -213,7 +213,7 @@ class PyGhidraScript(dict):
         """
         self._script.set(state, monitor, writer)
 
-    def run(self, script_path: str = None, script_args: List[str] = None):
+    def run(self, script_path: Optional[str] = None, script_args: Optional[List[str]] = None):
         """
         Run this GhidraScript
 

--- a/pyhidra/win_shortcut.py
+++ b/pyhidra/win_shortcut.py
@@ -3,6 +3,7 @@ import sys
 import sysconfig
 from pathlib import Path
 from pyhidra import DeferredPyhidraLauncher
+from typing import Optional
 
 
 # creating a shortcut with the winapi to have a set app id is trivial right?
@@ -10,7 +11,7 @@ from pyhidra import DeferredPyhidraLauncher
 
 
 
-def create_shortcut(install_dir: Path = None):
+def create_shortcut(install_dir: Optional[Path] = None):
     """Creates a shortcut to Ghidra (with pyhidra) on the desktop."""
 
     link = Path("~/Desktop/Ghidra (pyhidra).lnk").expanduser()


### PR DESCRIPTION
Currently, there are implicit `Optional` function arguments used by `pyhidra`. PEP 484 prohibits implicit `Optional`. This PR implements the explicit `Optional` function arguments, helping aid python type hint checkers.

## Reproduction

```
pip install mypy
mypy . | grep implicit
```

```
❯ mypy . | grep implicit                                                                                                        
pyhidra/linux_shortcut.py:38: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True                                                                                                                     
pyhidra/core.py:86: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
pyhidra/core.py:101: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
...

```